### PR TITLE
publish calendar items for use by Method Plugin

### DIFF
--- a/client/calendar.coffee
+++ b/client/calendar.coffee
@@ -74,7 +74,20 @@ format = (rows) ->
 	for row in rows
 		"""<tr><td>#{show row.date, row.span}<td>#{row.label}"""
 
-module.exports = {parse, apply, format} if module?
+dateAsValue = (date) ->
+	days = Math.floor(date.getTime() / (1000 * 60 * 60 * 24))
+	units : ["days"]
+	value : days
+
+radarSource = ($item, results) ->
+	data = {}
+	for row in results
+		data[row.label] = dateAsValue(row.date)
+		
+	$item.addClass 'radar-source'
+	$item.get(0).radarData = -> data
+
+module.exports = {parse, apply, format, radarSource} if module?
 
 
 emit = (div, item) ->
@@ -82,6 +95,7 @@ emit = (div, item) ->
 	wiki.log 'calendar rows', rows
 	results = apply {}, {}, new Date(), rows
 	wiki.log 'calendar results', results
+	radarSource div, results	
 	div.append """
 		<table style="width:100%; background:#eee; padding:.8em; margin-bottom:5px;">#{format(results).join ''}</table>
 	"""

--- a/client/calendar.coffee
+++ b/client/calendar.coffee
@@ -57,6 +57,10 @@ apply = (input, output, date, rows) ->
 			output[row.label] = {date}
 			output[row.label].span = row.span if row.span?
 		row.date = date
+		radarValue = dateAsValue(row.date, row.span)
+		row.units = radarValue.units
+		row.value = radarValue.value
+		row.precision = radarValue.precision
 		result.push row
 	result
 
@@ -91,15 +95,18 @@ unitsFor =
 	LATE:		'decade'
 
 dateAsValue = (date, span) ->
-	precision = precisionFor[span] ? precisionFor.DAY
+	precisionInMilliseconds = precisionFor[span] ? precisionFor.DAY
 	units : [unitsFor[span] ? unitsFor.DAY]
-	value : (Math.floor(date.getTime() / precision))
-	precision : precision
+	value : (Math.floor(date.getTime() / precisionInMilliseconds))
+	precision : precisionInMilliseconds
 
 radarSource = ($item, results) ->
 	data = {}
 	for row in results
-		data[row.label] = dateAsValue(row.date, row.span)
+		data[row.label] =
+			units: row.units
+			value: row.value
+			precision: row.precision
 
 	$item.addClass 'radar-source'
 	$item.get(0).radarData = -> data

--- a/client/calendar.coffee
+++ b/client/calendar.coffee
@@ -27,7 +27,7 @@ parse = (text) ->
 				result.year = +m[1]+1900
 				span result, 'DECADE'
 			else if (m = spans.indexOf word) >= 0
-			  result.span = spans[m]
+				result.span = spans[m]
 			else if (m = months.indexOf word[0..2]) >= 0
 				result.month = m+1
 				span result, 'MONTH'
@@ -74,16 +74,33 @@ format = (rows) ->
 	for row in rows
 		"""<tr><td>#{show row.date, row.span}<td>#{row.label}"""
 
-dateAsValue = (date) ->
-	days = Math.floor(date.getTime() / (1000 * 60 * 60 * 24))
-	units : ["days"]
-	value : days
+precisionFor =
+	DAY:		1000 * 60 * 60 * 24
+	MONTH:	1000 * 60 * 60 * 24 * 365.25 / 12
+	YEAR:		1000 * 60 * 60 * 24 * 365.25
+	DECADE: 1000 * 60 * 60 * 24 * 365.25 * 10
+	EARLY:	1000 * 60 * 60 * 24 * 365.25 * 10
+	LATE:		1000 * 60 * 60 * 24 * 365.25 * 10
+
+unitsFor =
+	DAY:		'day'
+	MONTH:	'month'
+	YEAR:		'year'
+	DECADE: 'decade'
+	EARLY:	'decade'
+	LATE:		'decade'
+
+dateAsValue = (date, span) ->
+	precision = precisionFor[span] ? precisionFor.DAY
+	units : [unitsFor[span] ? unitsFor.DAY]
+	value : (Math.floor(date.getTime() / precision))
+	precision : precision
 
 radarSource = ($item, results) ->
 	data = {}
 	for row in results
-		data[row.label] = dateAsValue(row.date)
-		
+		data[row.label] = dateAsValue(row.date, row.span)
+
 	$item.addClass 'radar-source'
 	$item.get(0).radarData = -> data
 
@@ -95,7 +112,7 @@ emit = (div, item) ->
 	wiki.log 'calendar rows', rows
 	results = apply {}, {}, new Date(), rows
 	wiki.log 'calendar results', results
-	radarSource div, results	
+	radarSource div, results
 	div.append """
 		<table style="width:100%; background:#eee; padding:.8em; margin-bottom:5px;">#{format(results).join ''}</table>
 	"""

--- a/client/calendar.coffee
+++ b/client/calendar.coffee
@@ -78,7 +78,7 @@ precisionFor =
 	DAY:		1000 * 60 * 60 * 24
 	MONTH:	1000 * 60 * 60 * 24 * 365.25 / 12
 	YEAR:		1000 * 60 * 60 * 24 * 365.25
-	DECADE: 1000 * 60 * 60 * 24 * 365.25 * 10
+	DECADE:	1000 * 60 * 60 * 24 * 365.25 * 10
 	EARLY:	1000 * 60 * 60 * 24 * 365.25 * 10
 	LATE:		1000 * 60 * 60 * 24 * 365.25 * 10
 
@@ -86,7 +86,7 @@ unitsFor =
 	DAY:		'day'
 	MONTH:	'month'
 	YEAR:		'year'
-	DECADE: 'decade'
+	DECADE:	'decade'
 	EARLY:	'decade'
 	LATE:		'decade'
 

--- a/factory.json
+++ b/factory.json
@@ -1,0 +1,5 @@
+{
+  "name": "Calendar",
+  "title": "Calendar Plugin",
+  "category": "data"
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -53,14 +53,17 @@ describe 'calendar plugin', ->
 			expect(output).to.eql {'April Fools Day': {date: new Date(2013, 4-1), span:'DAY'}}
 
 	describe 'radarSource', ->
-		label = 'Starts Now'
 		mock = {}
 		beforeEach ->
 			mock.el = {}
 			mock.$el =
 				addClass : (c) -> mock.actualClass = c
 				get : (n) -> mock.el
-			report.radarSource(mock.$el, [label: label, date: new Date('2015-09-01')])
+			results = report.apply {}, {}, new Date(), report.parse('''
+				2015 SEP 1 Starts Now
+				LATE 90S Some languages were born
+			''')
+			report.radarSource(mock.$el, results)
 
 		it 'calls addClass with "radar-source"', ->
 			expect(mock.actualClass).to.be 'radar-source'
@@ -69,18 +72,26 @@ describe 'calendar plugin', ->
 			expect(mock.el).to.have.key 'radarData'
 
 		it 'uses the labels as keys in the radarData', ->
-			expect(mock.el.radarData()).to.have.key label
+			expect(mock.el.radarData()).to.have.key 'Starts Now'
 
-		it 'puts the days since the Epoch into the values in the radarData', ->
+		it 'puts the distance from the Epoch into the values in the radarData', ->
 			data = mock.el.radarData()
-			expect(data[label]).to.have.key 'value'
-			expect(data[label].value).to.eql 16679
+			expect(data['Starts Now']).to.have.key 'value'
+			expect(data['Starts Now'].value).to.eql 16679
 
-		it 'uses "weeks" as the units of the values in the radarData', ->
+		it 'specifies units & precision with values in the radarData', ->
 			data = mock.el.radarData()
-			expect(data[label]).to.have.key 'units'
-			expect(data[label].units).to.eql ['days']
-	
+			expect(data['Starts Now']).to.have.key 'units'
+			expect(data['Starts Now'].units).to.eql ['day']
+			expect(data['Starts Now']).to.have.key 'precision'
+			expect(data['Starts Now'].precision).to.eql 86400000
+
+		it 'chooses units & precision to match the parsed span of the date', ->
+			data = mock.el.radarData()
+			expect(data['Some languages were born']).to.have.key 'units'
+			expect(data['Some languages were born'].units).to.eql ['decade']
+			expect(data['Some languages were born']).to.have.key 'precision'
+			expect(data['Some languages were born'].precision).to.eql 315576000000.0
 
 	# describe 'formatting', ->
 	# 	it 'returns an array of strings', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -76,22 +76,27 @@ describe 'calendar plugin', ->
 
 		it 'puts the distance from the Epoch into the values in the radarData', ->
 			data = mock.el.radarData()
+			daysSinceEpoch =
+				new Date('2015-09-01').getTime() /
+				(24 * 60 * 60 * 1000) # 16,679
 			expect(data['Starts Now']).to.have.key 'value'
-			expect(data['Starts Now'].value).to.eql 16679
+			expect(data['Starts Now'].value).to.eql daysSinceEpoch
 
 		it 'specifies units & precision with values in the radarData', ->
 			data = mock.el.radarData()
+			oneDayInMS = 24 * 60 * 60 * 1000 # 86,400,000
 			expect(data['Starts Now']).to.have.key 'units'
 			expect(data['Starts Now'].units).to.eql ['day']
 			expect(data['Starts Now']).to.have.key 'precision'
-			expect(data['Starts Now'].precision).to.eql 86400000
+			expect(data['Starts Now'].precision).to.eql oneDayInMS
 
 		it 'chooses units & precision to match the parsed span of the date', ->
 			data = mock.el.radarData()
+			oneDecadeInMS = 10 * 365.25 * 24 * 60 * 60 * 1000 # 315,576,000,000
 			expect(data['Some languages were born']).to.have.key 'units'
 			expect(data['Some languages were born'].units).to.eql ['decade']
 			expect(data['Some languages were born']).to.have.key 'precision'
-			expect(data['Some languages were born'].precision).to.eql 315576000000.0
+			expect(data['Some languages were born'].precision).to.eql oneDecadeInMS
 
 	# describe 'formatting', ->
 	# 	it 'returns an array of strings', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -37,19 +37,35 @@ describe 'calendar plugin', ->
 
 		today = new Date 2013, 2-1, 3
 		interview = new Date 2006, 4-1, 24
+		oneDayInMS = 24*60*60*1000
 
 		it 'recalls input', ->
 			input = {interview: {date: interview}}
 			output = {}
 			rows = report.parse "interview"
-			expect(report.apply input, output, today, rows).to.eql [{date: interview, label:'interview'}]
+			expect(report.apply input, output, today, rows).to.eql [
+				date: interview
+				label:'interview'
+				units: ['day']
+				value: interview.getTime() / oneDayInMS
+				precision: oneDayInMS
+			]
 
 		it 'extends today', ->
 			input = {}
 			output = {}
 			rows = report.parse "APRIL 1 April Fools Day"
 			results = report.apply input, output, today, rows
-			expect(results).to.eql [{date: new Date(2013, 4-1, 1), month: 4, day: 1, span:'DAY', label: 'April Fools Day'}]
+			expect(results).to.eql [
+				date: new Date(2013, 4-1, 1)
+				month: 4
+				day: 1
+				span:'DAY'
+				label: 'April Fools Day'
+				units: ['day']
+				value: new Date(2013, 4-1, 1).getTime() / oneDayInMS
+				precision: oneDayInMS
+			]
 			expect(output).to.eql {'April Fools Day': {date: new Date(2013, 4-1, 1), span:'DAY'}}
 
 	describe 'radarSource', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -52,6 +52,34 @@ describe 'calendar plugin', ->
 			expect(results).to.eql [{date: new Date(2013, 4-1), month: 4, day: 1, span:'DAY', label: 'April Fools Day'}]
 			expect(output).to.eql {'April Fools Day': {date: new Date(2013, 4-1), span:'DAY'}}
 
+	describe 'radarSource', ->
+		label = 'Starts Now'
+		mock = {}
+		beforeEach ->
+			mock.el = {}
+			mock.$el =
+				addClass : (c) -> mock.actualClass = c
+				get : (n) -> mock.el
+			report.radarSource(mock.$el, [label: label, date: new Date('2015-09-01')])
+
+		it 'calls addClass with "radar-source"', ->
+			expect(mock.actualClass).to.be 'radar-source'
+
+		it 'adds radarData() to the DOM element', ->
+			expect(mock.el).to.have.key 'radarData'
+
+		it 'uses the labels as keys in the radarData', ->
+			expect(mock.el.radarData()).to.have.key label
+
+		it 'puts the days since the Epoch into the values in the radarData', ->
+			data = mock.el.radarData()
+			expect(data[label]).to.have.key 'value'
+			expect(data[label].value).to.eql 16679
+
+		it 'uses "weeks" as the units of the values in the radarData', ->
+			data = mock.el.radarData()
+			expect(data[label]).to.have.key 'units'
+			expect(data[label].units).to.eql ['days']
 	
 
 	# describe 'formatting', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -49,8 +49,8 @@ describe 'calendar plugin', ->
 			output = {}
 			rows = report.parse "APRIL 1 April Fools Day"
 			results = report.apply input, output, today, rows
-			expect(results).to.eql [{date: new Date(2013, 4-1), month: 4, day: 1, span:'DAY', label: 'April Fools Day'}]
-			expect(output).to.eql {'April Fools Day': {date: new Date(2013, 4-1), span:'DAY'}}
+			expect(results).to.eql [{date: new Date(2013, 4-1, 1), month: 4, day: 1, span:'DAY', label: 'April Fools Day'}]
+			expect(output).to.eql {'April Fools Day': {date: new Date(2013, 4-1, 1), span:'DAY'}}
 
 	describe 'radarSource', ->
 		mock = {}


### PR DESCRIPTION
I've been playing with the Method Plugin and federated wiki.  Today's experiment was to see if I could compute my kids' allowances.  With these modifications to the Calendar plugin, I'm able to do it with a little subtraction and some fun application of unit conversion.

Calendar:

```
Today
JUL 5 Start Date
```

Method (unit conversions):

```
7 (days) per (weeks)
3 Allowance (dollars) per (weeks)
```

Method:

```
Today
Start Date
CALC Today - Start
SUM Period (weeks)
SUM Saved (dollars)
```
